### PR TITLE
ci: ensure release-plz opens PRs only via aprilnea[bot]

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,6 +24,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -38,12 +40,19 @@ jobs:
       group: release-plz-pr-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
### Motivation

- Prevent duplicate release PRs created by both `aprilnea[bot]` and `github-actions[bot]` by ensuring the release tooling consistently uses the GitHub App identity.

### Description

- Generate a GitHub App token in both the `release-plz-release` and `release-plz-pr` jobs using `actions/create-github-app-token@v1` and store it in `steps.app-token.outputs.token`.
- Use the app token for `actions/checkout@v4` by setting `token: ${{ steps.app-token.outputs.token }}` so checkouts run as the app installation user.
- Replace `secrets.GITHUB_TOKEN` with the app token for `GITHUB_TOKEN` in the `release-plz-pr` job so PRs are opened by the app (`aprilnea[bot]`).
- Explicitly set `with: command: release` for the `release-plz-release` job to avoid ambiguity in action behavior.

### Testing

- Parsed the modified workflow YAML successfully using Ruby with `YAML.load_file('.github/workflows/release-plz.yml')`, which returned `ok`.
- Reviewed the workflow diff to confirm only the intended workflow changes were introduced, and validated step/token references are present and consistent.
- Attempted to parse with Python `PyYAML` but the environment lacked the `yaml` module, so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4c685234833285269bff17897450)