### PR TITLE
feat(provider): add Factory (Droid) provider via WorkOS device code flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/auth/src/factory.rs
+++ b/crates/auth/src/factory.rs
@@ -1,0 +1,197 @@
+//! Factory (Droid) device code authorization flow via `WorkOS`.
+//!
+//! Implements the OAuth 2.0 Device Authorization Grant used by Factory.
+//! After initial login, an org-scoped token is obtained via `/api/cli/org`
+//! resolution and token refresh with the `organization_id`.
+
+use byokey_types::{ByokError, OAuthToken, traits::Result};
+
+/// `WorkOS` device code request endpoint.
+pub const DEVICE_CODE_URL: &str = "https://api.workos.com/user_management/authorize/device";
+
+/// `WorkOS` token exchange / refresh endpoint.
+pub const TOKEN_URL: &str = "https://api.workos.com/user_management/authenticate";
+
+/// Public OAuth client ID for Factory CLI.
+pub const CLIENT_ID: &str = "client_01HNM792M5G5G1A2THWPXKFMXB";
+
+/// Factory API base URL for org resolution.
+pub const FACTORY_API_BASE: &str = "https://api.factory.ai";
+
+/// Parsed response from the device code request.
+#[derive(Debug)]
+pub struct DeviceCodeResponse {
+    /// Unique device verification code.
+    pub device_code: String,
+    /// Short code the user enters at the verification URI.
+    pub user_code: String,
+    /// Full URL including the user code for one-click authorization.
+    pub verification_uri: String,
+    /// Seconds until the device code expires.
+    pub expires_in: u64,
+    /// Minimum polling interval in seconds.
+    pub interval: u64,
+}
+
+/// Parse the device code endpoint JSON response.
+///
+/// # Errors
+///
+/// Returns an error if `device_code` or `user_code` is missing.
+pub fn parse_device_code_response(json: &serde_json::Value) -> Result<DeviceCodeResponse> {
+    Ok(DeviceCodeResponse {
+        device_code: json
+            .get("device_code")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| ByokError::Auth("missing device_code".into()))?
+            .to_string(),
+        user_code: json
+            .get("user_code")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| ByokError::Auth("missing user_code".into()))?
+            .to_string(),
+        verification_uri: json
+            .get("verification_uri_complete")
+            .or_else(|| json.get("verification_uri"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("https://api.workos.com/user_management/authorize/device")
+            .to_string(),
+        expires_in: json
+            .get("expires_in")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(300),
+        interval: json
+            .get("interval")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(5),
+    })
+}
+
+/// Parse the token endpoint JSON response into an [`OAuthToken`].
+///
+/// Factory tokens are JWTs with an `exp` claim. The expiry is extracted
+/// from the JWT payload to enable automatic refresh.
+///
+/// # Errors
+///
+/// Returns an error if the response is missing the `access_token` field.
+pub fn parse_token_response(json: &serde_json::Value) -> Result<OAuthToken> {
+    let access_token = json
+        .get("access_token")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| ByokError::Auth("missing access_token".into()))?
+        .to_string();
+
+    let mut token = OAuthToken::new(access_token.clone());
+
+    if let Some(rt) = json
+        .get("refresh_token")
+        .and_then(serde_json::Value::as_str)
+    {
+        token = token.with_refresh(rt);
+    }
+
+    // Try to extract expiry from JWT `exp` claim.
+    if let Some(exp) = decode_jwt_exp(&access_token) {
+        token.expires_at = Some(exp);
+    } else if let Some(exp) = json.get("expires_in").and_then(serde_json::Value::as_u64) {
+        token = token.with_expiry(exp);
+    }
+
+    Ok(token)
+}
+
+/// Resolve the user's `WorkOS` organization ID from Factory.
+///
+/// # Errors
+///
+/// Returns an error if the API call fails or no organization is found.
+pub async fn resolve_org(access_token: &str, http: &rquest::Client) -> Result<String> {
+    let resp = http
+        .get(format!("{FACTORY_API_BASE}/api/cli/org"))
+        .header("authorization", format!("Bearer {access_token}"))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(ByokError::Auth(format!(
+            "Factory org resolution failed: {text}"
+        )));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| ByokError::Auth(format!("failed to parse org response: {e}")))?;
+
+    json.get("workosOrgIds")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|arr| arr.first())
+        .and_then(serde_json::Value::as_str)
+        .map(String::from)
+        .ok_or_else(|| {
+            ByokError::Auth(
+                "no organization found; visit https://app.factory.ai/cli-onboarding".into(),
+            )
+        })
+}
+
+/// Decode the `exp` claim from a JWT without verifying the signature.
+fn decode_jwt_exp(token: &str) -> Option<u64> {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    json.get("exp").and_then(serde_json::Value::as_u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_parse_device_code() {
+        let resp = json!({
+            "device_code": "dc-123",
+            "user_code": "ABCD-1234",
+            "verification_uri_complete": "https://auth.workos.com/device?code=ABCD-1234",
+            "expires_in": 300,
+            "interval": 5
+        });
+        let dc = parse_device_code_response(&resp).unwrap();
+        assert_eq!(dc.user_code, "ABCD-1234");
+        assert_eq!(dc.expires_in, 300);
+    }
+
+    #[test]
+    fn test_parse_token_ok() {
+        let resp = json!({
+            "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTl9.signature",
+            "refresh_token": "rt_abc"
+        });
+        let t = parse_token_response(&resp).unwrap();
+        assert!(t.access_token.starts_with("eyJ"));
+        assert_eq!(t.refresh_token, Some("rt_abc".into()));
+    }
+
+    #[test]
+    fn test_parse_token_missing() {
+        assert!(parse_token_response(&json!({})).is_err());
+    }
+
+    #[test]
+    fn test_decode_jwt_exp() {
+        // {"exp": 9999999999} base64url-encoded
+        let token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTl9.signature";
+        assert_eq!(decode_jwt_exp(token), Some(9999999999));
+    }
+
+    #[test]
+    fn test_decode_jwt_exp_invalid() {
+        assert_eq!(decode_jwt_exp("not-a-jwt"), None);
+        assert_eq!(decode_jwt_exp("a.b"), None);
+    }
+}

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -10,6 +10,7 @@ pub mod claude;
 pub mod codex;
 pub mod copilot;
 pub mod credentials;
+pub mod factory;
 pub mod flow;
 pub mod gemini;
 pub mod iflow;

--- a/crates/provider/src/factory.rs
+++ b/crates/provider/src/factory.rs
@@ -1,0 +1,99 @@
+//! Factory executor — backend-only provider routing through Factory.ai proxy.
+//!
+//! Factory is a backend provider: it does not own any models directly.
+//! Configure other providers with `backend: factory` to route through it.
+//!
+//! Auth: device code flow → `WorkOS` token → org-scoped token (refresh managed by `AuthManager`).
+//! Format: `OpenAI` passthrough (no translation needed).
+
+use crate::http_util::ProviderHttp;
+use async_trait::async_trait;
+use byokey_auth::AuthManager;
+use byokey_types::{
+    ChatRequest, ProviderId,
+    traits::{ProviderExecutor, ProviderResponse, Result},
+};
+use rquest::Client;
+use std::sync::Arc;
+
+/// Factory LLM proxy base URL (OpenAI-compatible endpoint).
+const API_BASE_URL: &str = "https://api.factory.ai/api/llm/o";
+
+/// User-Agent header matching the Factory CLI.
+const USER_AGENT: &str = "factory-cli/0.62.1";
+
+/// Executor for the Factory.ai API.
+pub struct FactoryExecutor {
+    ph: ProviderHttp,
+    api_key: Option<String>,
+    auth: Arc<AuthManager>,
+}
+
+impl FactoryExecutor {
+    /// Creates a new Factory executor with an optional API key and auth manager.
+    pub fn new(http: Client, api_key: Option<String>, auth: Arc<AuthManager>) -> Self {
+        Self {
+            ph: ProviderHttp::new(http),
+            api_key,
+            auth,
+        }
+    }
+
+    /// Obtains the Bearer token for Factory API requests.
+    ///
+    /// Uses the configured `api_key` if present, otherwise retrieves the
+    /// OAuth token from the auth manager (with automatic refresh).
+    async fn bearer_token(&self) -> Result<String> {
+        if let Some(key) = &self.api_key {
+            return Ok(key.clone());
+        }
+        let token = self.auth.get_token(&ProviderId::Factory).await?;
+        Ok(token.access_token)
+    }
+}
+
+#[async_trait]
+impl ProviderExecutor for FactoryExecutor {
+    async fn chat_completion(&self, request: ChatRequest) -> Result<ProviderResponse> {
+        let stream = request.stream;
+        let body = request.into_body();
+
+        let token = self.bearer_token().await?;
+
+        let builder = self
+            .ph
+            .client()
+            .post(format!("{API_BASE_URL}/v1/chat/completions"))
+            .header("authorization", format!("Bearer {token}"))
+            .header("user-agent", USER_AGENT)
+            .header("x-api-provider", "openai")
+            .header("x-session-id", uuid::Uuid::new_v4().to_string())
+            .header("x-assistant-message-id", uuid::Uuid::new_v4().to_string())
+            .header("content-type", "application/json")
+            .json(&body);
+
+        self.ph.send_passthrough(builder, stream).await
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use byokey_store::InMemoryTokenStore;
+
+    fn make_executor() -> FactoryExecutor {
+        let store = Arc::new(InMemoryTokenStore::new());
+        let auth = Arc::new(AuthManager::new(store, rquest::Client::new()));
+        FactoryExecutor::new(Client::new(), None, auth)
+    }
+
+    #[test]
+    fn test_supported_models_empty() {
+        let ex = make_executor();
+        assert!(ex.supported_models().is_empty());
+    }
+}

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -8,6 +8,7 @@ pub mod antigravity;
 pub mod claude;
 pub mod codex;
 pub mod copilot;
+pub mod factory;
 pub mod gemini;
 pub mod http_util;
 pub mod iflow;
@@ -22,6 +23,7 @@ pub use antigravity::AntigravityExecutor;
 pub use claude::ClaudeExecutor;
 pub use codex::CodexExecutor;
 pub use copilot::CopilotExecutor;
+pub use factory::FactoryExecutor;
 pub use gemini::GeminiExecutor;
 pub use iflow::IFlowExecutor;
 pub use kimi::KimiExecutor;
@@ -84,6 +86,7 @@ pub fn make_executor(
         ProviderId::Qwen => Some(Box::new(QwenExecutor::new(http, api_key, auth))),
         ProviderId::IFlow => Some(Box::new(IFlowExecutor::new(http, api_key, auth))),
         ProviderId::Kimi => Some(Box::new(KimiExecutor::new(http, api_key, auth))),
+        ProviderId::Factory => Some(Box::new(FactoryExecutor::new(http, api_key, auth))),
     }
 }
 
@@ -236,6 +239,14 @@ mod tests {
                 .iter()
                 .any(|m| m.starts_with("kimi-"))
         );
+    }
+
+    #[test]
+    fn test_make_executor_factory() {
+        let auth = make_auth();
+        let ex = make_executor(&ProviderId::Factory, None, auth, make_http());
+        assert!(ex.is_some());
+        assert!(ex.unwrap().supported_models().is_empty());
     }
 
     #[test]

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -32,6 +32,7 @@ futures-util.workspace = true
 bytes.workspace = true
 arc-swap.workspace = true
 tracing.workspace = true
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/proxy/src/factory.rs
+++ b/crates/proxy/src/factory.rs
@@ -15,8 +15,8 @@ use axum::{
     http::{HeaderMap, Method, StatusCode},
     response::{IntoResponse, Response},
 };
-use bytes::Bytes;
 use byokey_types::{ByokError, ProviderId};
+use bytes::Bytes;
 use futures_util::TryStreamExt as _;
 use std::sync::Arc;
 
@@ -50,7 +50,7 @@ async fn resolve_token(state: &AppState) -> Result<String, ApiError> {
 }
 
 /// Generic Factory passthrough handler.
-async fn factory_proxy(
+pub(crate) async fn factory_proxy(
     state: Arc<AppState>,
     provider: &str,
     llm_path: &str,
@@ -69,10 +69,7 @@ async fn factory_proxy(
         .header("user-agent", USER_AGENT)
         .header("x-api-provider", provider)
         .header("x-session-id", uuid::Uuid::new_v4().to_string())
-        .header(
-            "x-assistant-message-id",
-            uuid::Uuid::new_v4().to_string(),
-        );
+        .header("x-assistant-message-id", uuid::Uuid::new_v4().to_string());
 
     // Forward original headers, stripping hop-by-hop and auth.
     for (name, value) in &headers {
@@ -118,7 +115,11 @@ async fn factory_proxy(
             .get("accept")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("application/json");
-        Ok((upstream_status, [(axum::http::header::CONTENT_TYPE, content_type)], resp_bytes)
+        Ok((
+            upstream_status,
+            [(axum::http::header::CONTENT_TYPE, content_type)],
+            resp_bytes,
+        )
             .into_response())
     }
 }

--- a/crates/proxy/src/factory.rs
+++ b/crates/proxy/src/factory.rs
@@ -1,0 +1,157 @@
+//! Factory.ai passthrough proxy routes.
+//!
+//! Exposes `/factory/{provider}/*` endpoints that forward requests as-is to
+//! Factory's LLM proxy with auth injected. No model inspection, no format
+//! translation — the client speaks the provider's native API format directly.
+//!
+//! Routes:
+//! - `/factory/anthropic/*` → `https://api.factory.ai/api/llm/a/*`
+//! - `/factory/openai/*`    → `https://api.factory.ai/api/llm/o/*`
+//! - `/factory/google/*`    → `https://api.factory.ai/api/llm/g/*`
+
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{HeaderMap, Method, StatusCode},
+    response::{IntoResponse, Response},
+};
+use bytes::Bytes;
+use byokey_types::{ByokError, ProviderId};
+use futures_util::TryStreamExt as _;
+use std::sync::Arc;
+
+use crate::{AppState, error::ApiError};
+
+/// Factory API base URL.
+const FACTORY_BASE: &str = "https://api.factory.ai";
+
+/// User-Agent header matching the Factory CLI.
+const USER_AGENT: &str = "factory-cli/0.62.1";
+
+/// Headers that should not be forwarded to the upstream.
+const STRIP_HEADERS: &[&str] = &["host", "authorization"];
+
+/// Resolve the Factory bearer token from config API key or OAuth.
+async fn resolve_token(state: &AppState) -> Result<String, ApiError> {
+    let config = state.config.load();
+    if let Some(key) = config
+        .providers
+        .get(&ProviderId::Factory)
+        .and_then(|pc| pc.api_key.clone())
+    {
+        return Ok(key);
+    }
+    let token = state
+        .auth
+        .get_token(&ProviderId::Factory)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(token.access_token)
+}
+
+/// Generic Factory passthrough handler.
+async fn factory_proxy(
+    state: Arc<AppState>,
+    provider: &str,
+    llm_path: &str,
+    sub_path: &str,
+    method: Method,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    let token = resolve_token(&state).await?;
+    let upstream_url = format!("{FACTORY_BASE}/api/llm/{llm_path}/{sub_path}");
+
+    let mut builder = state
+        .http
+        .request(method, &upstream_url)
+        .header("authorization", format!("Bearer {token}"))
+        .header("user-agent", USER_AGENT)
+        .header("x-api-provider", provider)
+        .header("x-session-id", uuid::Uuid::new_v4().to_string())
+        .header(
+            "x-assistant-message-id",
+            uuid::Uuid::new_v4().to_string(),
+        );
+
+    // Forward original headers, stripping hop-by-hop and auth.
+    for (name, value) in &headers {
+        let n = name.as_str();
+        if STRIP_HEADERS.iter().any(|&s| n.eq_ignore_ascii_case(s)) {
+            continue;
+        }
+        builder = builder.header(name, value);
+    }
+
+    let resp = builder
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| ApiError(ByokError::from(e)))?;
+
+    let status = resp.status();
+    let upstream_status = StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+
+    let is_stream = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.contains("text/event-stream"));
+
+    if is_stream {
+        let byte_stream = resp
+            .bytes_stream()
+            .map_err(|e| std::io::Error::other(e.to_string()));
+        Ok(Response::builder()
+            .status(upstream_status)
+            .header("content-type", "text/event-stream")
+            .header("cache-control", "no-cache")
+            .header("x-accel-buffering", "no")
+            .body(Body::from_stream(byte_stream))
+            .expect("valid response"))
+    } else {
+        let resp_bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| ApiError(ByokError::from(e)))?;
+        let content_type = headers
+            .get("accept")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/json");
+        Ok((upstream_status, [(axum::http::header::CONTENT_TYPE, content_type)], resp_bytes)
+            .into_response())
+    }
+}
+
+/// `ANY /factory/anthropic/{*path}` — Anthropic native passthrough via Factory.
+pub async fn factory_anthropic(
+    State(state): State<Arc<AppState>>,
+    method: Method,
+    headers: HeaderMap,
+    Path(path): Path<String>,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    factory_proxy(state, "anthropic", "a", &path, method, headers, body).await
+}
+
+/// `ANY /factory/openai/{*path}` — `OpenAI` native passthrough via Factory.
+pub async fn factory_openai(
+    State(state): State<Arc<AppState>>,
+    method: Method,
+    headers: HeaderMap,
+    Path(path): Path<String>,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    factory_proxy(state, "openai", "o", &path, method, headers, body).await
+}
+
+/// `ANY /factory/google/{*path}` — Google/Gemini native passthrough via Factory.
+pub async fn factory_google(
+    State(state): State<Arc<AppState>>,
+    method: Method,
+    headers: HeaderMap,
+    Path(path): Path<String>,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    factory_proxy(state, "google", "g", &path, method, headers, body).await
+}

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -7,6 +7,7 @@ mod amp;
 mod amp_provider;
 mod chat;
 mod error;
+mod factory;
 mod messages;
 mod models;
 pub mod usage;
@@ -116,6 +117,13 @@ pub fn make_router(state: Arc<AppState>) -> Router {
             "/api/provider/google/v1beta/models/{action}",
             post(amp_provider::gemini_native_passthrough),
         )
+        // Factory passthrough routes
+        .route(
+            "/factory/anthropic/{*path}",
+            any(factory::factory_anthropic),
+        )
+        .route("/factory/openai/{*path}", any(factory::factory_openai))
+        .route("/factory/google/{*path}", any(factory::factory_google))
         // Catch-all: forward remaining /api/* routes to ampcode.com
         .route("/api/{*path}", any(amp_provider::amp_management_proxy))
         // Management API

--- a/crates/types/src/provider.rs
+++ b/crates/types/src/provider.rs
@@ -16,6 +16,7 @@ pub enum ProviderId {
     Qwen,
     Kimi,
     IFlow,
+    Factory,
 }
 
 impl fmt::Display for ProviderId {
@@ -30,6 +31,7 @@ impl fmt::Display for ProviderId {
             Self::Qwen => write!(f, "qwen"),
             Self::Kimi => write!(f, "kimi"),
             Self::IFlow => write!(f, "iflow"),
+            Self::Factory => write!(f, "factory"),
         }
     }
 }
@@ -54,6 +56,7 @@ impl std::str::FromStr for ProviderId {
             "qwen" | "alibaba" => Ok(Self::Qwen),
             "kimi" | "moonshot" => Ok(Self::Kimi),
             "iflow" | "zai" | "glm" => Ok(Self::IFlow),
+            "factory" | "droid" => Ok(Self::Factory),
             other => Err(crate::ByokError::UnsupportedModel(other.to_string())),
         }
     }
@@ -73,6 +76,7 @@ impl ProviderId {
             Self::Qwen,
             Self::Kimi,
             Self::IFlow,
+            Self::Factory,
         ]
     }
 }
@@ -102,6 +106,7 @@ mod tests {
         assert_eq!(ProviderId::Qwen.to_string(), "qwen");
         assert_eq!(ProviderId::Kimi.to_string(), "kimi");
         assert_eq!(ProviderId::IFlow.to_string(), "iflow");
+        assert_eq!(ProviderId::Factory.to_string(), "factory");
     }
 
     #[test]
@@ -121,6 +126,10 @@ mod tests {
         assert_eq!(ProviderId::from_str("qwen").unwrap(), ProviderId::Qwen);
         assert_eq!(ProviderId::from_str("kimi").unwrap(), ProviderId::Kimi);
         assert_eq!(ProviderId::from_str("iflow").unwrap(), ProviderId::IFlow);
+        assert_eq!(
+            ProviderId::from_str("factory").unwrap(),
+            ProviderId::Factory
+        );
     }
 
     #[test]
@@ -136,6 +145,7 @@ mod tests {
         assert_eq!(ProviderId::from_str("moonshot").unwrap(), ProviderId::Kimi);
         assert_eq!(ProviderId::from_str("zai").unwrap(), ProviderId::IFlow);
         assert_eq!(ProviderId::from_str("glm").unwrap(), ProviderId::IFlow);
+        assert_eq!(ProviderId::from_str("droid").unwrap(), ProviderId::Factory);
     }
 
     #[test]
@@ -156,6 +166,7 @@ mod tests {
             ProviderId::Qwen,
             ProviderId::Kimi,
             ProviderId::IFlow,
+            ProviderId::Factory,
         ] {
             let json = serde_json::to_string(&p).unwrap();
             let back: ProviderId = serde_json::from_str(&json).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -778,6 +778,7 @@ async fn cmd_status(db: Option<PathBuf>) -> Result<()> {
         ProviderId::Qwen,
         ProviderId::Kimi,
         ProviderId::IFlow,
+        ProviderId::Factory,
     ];
     for provider in &providers {
         let accounts = auth.list_accounts(provider).await.unwrap_or_default();


### PR DESCRIPTION
Implements OAuth 2.0 Device Authorization Grant for Factory.ai through WorkOS, with org-scoped token resolution and automatic refresh.

This PR is still in darft, further tests are needed and API changes are welcome.